### PR TITLE
Remove resizing again

### DIFF
--- a/lib/views/terminal.coffee
+++ b/lib/views/terminal.coffee
@@ -40,10 +40,10 @@ class TerminalView extends View
     @openColor = @term.element.style.color
 
   handleEvents: ->
-    @on 'focus', =>
-      @fitTerminal()
-    @on 'mousedown', '.terminal-view-resize-handle', (e) =>
-      @resizeStarted(e)
+    # @on 'focus', =>
+    #   @fitTerminal()
+    # @on 'mousedown', '.terminal-view-resize-handle', (e) =>
+    #   @resizeStarted(e)
 
     @$termEl.on 'focus', (e) =>
       @term.focus()

--- a/styles/integrated-learn-environment.less
+++ b/styles/integrated-learn-environment.less
@@ -4,9 +4,9 @@
   .terminal-view-resize-handle {
     height: 4px;
 
-    &:hover {
-      cursor: row-resize;
-    }
+    // &:hover {
+    //   cursor: row-resize;
+    // }
   }
 
   .learn-terminal {


### PR DESCRIPTION
reopens #124 

everything works, the only problem is that making the terminal smaller destroys the bottom rows, hiding the prompt & cursor. `ctrl-c` or `ctrl-l` will bring it back, but it looks a little janky for a minute. need a fix for that: resizing should always push the prompt to the bottom of the window, and then hide rows from the top, a la Terminal
