### PR TITLE
Reset disabled tree-view & make Logout more accessible

### DIFF
--- a/lib/learn-ide.coffee
+++ b/lib/learn-ide.coffee
@@ -10,6 +10,8 @@ Notifier = require './notifier'
 atomHelper = require './atom-helper'
 config = require './config'
 auth = require './auth'
+remote = require 'remote'
+BrowserWindow = remote.require('browser-window')
 
 module.exports =
   activate: (state) ->
@@ -44,7 +46,7 @@ module.exports =
     @termView.toggle()
 
   activateStatusView: (state) ->
-    @statusView = new StatusView state, @term, {isTerminalWindow: @isTerminalWindow}
+    @statusView = new StatusView state, @term, {@isTerminalWindow}
 
     bus.on 'terminal:popin', () =>
       @statusView.onTerminalPopIn()
@@ -74,6 +76,7 @@ module.exports =
       'learn-ide:open': (e) => @termView.openLab(e.detail.path)
       'learn-ide:toggle-terminal': () => @termView.toggle()
       'learn-ide:toggle-focus': => @termView.toggleFocus()
+      'learn-ide:logout': => @logout()
       'learn-ide:reset': =>
         @term.term.write('\n\rReconnecting...\r')
       'application:update-ile': -> (new Updater).checkForUpdate()
@@ -111,3 +114,17 @@ module.exports =
   serialize: ->
     termViewState: @termView.serialize()
     fsViewState: @statusView.serialize()
+
+  logout: ->
+    atom.config.unset('learn-ide.oauthToken')
+
+    github = new BrowserWindow(show: false)
+    github.webContents.on 'did-finish-load', -> github.show()
+    github.loadUrl('https://github.com/logout')
+
+    learn = new BrowserWindow(show: false)
+    learn.webContents.on 'did-finish-load', -> learn.destroy()
+    learn.loadUrl('https://learn.co/sign_out')
+
+    atom.reload()
+

--- a/menus/learn-ide.cson
+++ b/menus/learn-ide.cson
@@ -19,17 +19,11 @@
       'command': 'learn-ide:toggle-terminal'
     }
   ]
-  '.tree-view.full-menu .project-root .entries .directory > .header': [
-    {
-      'label': 'Resync with Learn IDE Server'
-      'command': 'learn-ide:resync'
-    }
-  ]
 'menu': [
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'Learn.co'
+      'label': 'Learn IDE'
       'submenu': [
         {
           'label': 'Focus Terminal'
@@ -42,6 +36,10 @@
         {
           'label': 'Reconnect'
           'command': 'learn-ide:reset'
+        }
+        {
+          'label': 'Logout'
+          'command': 'learn-ide:logout'
         }
       ]
     ]


### PR DESCRIPTION
Had an issue where `localStorage.disableTreeView` returned true on launch—I think because it wasn't cleared out after using a pop-out terminal in a previous session. This removes the key whenever the package is deactivated.

@joshrowley seem cool?
