### PR TITLE
Remove decoding of terminal messages

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -41,7 +41,8 @@ export default class Terminal {
           return
         }
 
-        this.emit('message', terminal)
+        var decoded = new Buffer(terminal, 'base64').toString()
+        this.emit('message', decoded)
       })
 
       this.socket.on('close', e => this.emit('close', e))


### PR DESCRIPTION
Turns out, we actually do need to send encoded messages from the server. Vim, and probably other things, throw some pretty weird stuff at the terminal, and it super breaks the server's JSON parsing abilities.