### PR TITLE
Disable phoenix reconnect and update for reset functionality

### DIFF
--- a/lib/learn-ide.js
+++ b/lib/learn-ide.js
@@ -19,6 +19,7 @@ import updater from './updater'
 import {CompositeDisposable} from 'atom'
 import {name, version} from '../package.json'
 import {shell} from 'electron'
+import {getLabSlug} from './learn-open'
 
 window.LEARN_IDE_VERSION = version;
 
@@ -69,7 +70,8 @@ export default {
       port: config.port,
       path: config.path,
       token: this.token.get(),
-      username: username.get()
+      username: username.get(),
+      labSlug: getLabSlug()
     });
 
     this.termView = new TerminalView(this.term);
@@ -160,12 +162,6 @@ export default {
         colors.parseJSON(newValue);
       })
     )
-
-    var openPath = localStorage.get('learnOpenLabOnActivation');
-    if (openPath) {
-      localStorage.delete('learnOpenLabOnActivation');
-      this.learnOpen(openPath);
-    }
   },
 
   activateNotifier() {

--- a/lib/learn-ide.js
+++ b/lib/learn-ide.js
@@ -83,13 +83,6 @@ export default {
 
   activateEventHandlers() {
     atomHelper.trackFocusedWindow();
-
-    // listen for learn:open event from other render processes (url handler)
-    bus.on('learn:open', lab => {
-      this.learnOpen(lab.slug);
-      atom.getCurrentWindow().focus();
-    });
-
     // tidy up when the window closes
     atom.getCurrentWindow().on('close', () => this.cleanup());
   },

--- a/lib/learn-open.js
+++ b/lib/learn-open.js
@@ -1,0 +1,12 @@
+'use babel'
+
+import localStorage from './local-storage'
+
+let openPath = localStorage.get('learnOpenLabOnActivation');
+localStorage.delete('learnOpenLabOnActivation');
+
+export default {
+  getLabSlug () {
+    return openPath || null
+  }
+}

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -30,7 +30,9 @@ export default class Terminal {
     this.channel = this.socket.channel(this.channelName())
 
     this.channel.join()
-      .receive('error', (e) => { console.log('error connecting to session', e) })
+      .receive('error', (e) => {
+        atom.emitter.emit('learn-ide:error-joining-channel')
+      })
       .receive('ok', (e) => {
         atom.emitter.emit('learn-ide:did-join-channel', this.channel)
         this.emit('open', e)

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -2,6 +2,7 @@
 
 import { EventEmitter } from 'events'
 import { Socket } from 'phoenix'
+import { name } from '../package.json'
 
 export default class Terminal {
   constructor(args={}) {
@@ -63,7 +64,9 @@ export default class Terminal {
   }
 
   channelName() {
-    return `session:${this.username}:${this.labSlug || 'lobby'}`
+    let defaultOpen = atom.config.get(`${name}.openOnHome`) ? 'home' : 'temporary'
+
+    return `session:${this.username}:${this.labSlug || defaultOpen}`
   }
 
   reset() {

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -23,7 +23,10 @@ export default class Terminal {
   connect() {
     this.socket = new Socket(this.url(), {params: {token: this.token, client: 'atom'}})
     this.socket.connect()
+    this.joinChannel()
+  }
 
+  joinChannel() {
     this.channel = this.socket.channel(this.channelName())
 
     this.channel.join()
@@ -42,8 +45,7 @@ export default class Terminal {
 
     this.channel.onError((e) => {
       this.channel.leave()
-      this.socket.reconnectTimer.callback = () => { } // noops to prevent auto reconnects
-      this.socket.disconnect()
+
       this.emit('error', e)
     })
   }
@@ -70,7 +72,7 @@ export default class Terminal {
   }
 
   reset() {
-    return this.connect()
+    this.joinChannel()
   }
 
   send(msg) {

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -38,7 +38,13 @@ export default class Terminal {
     })
 
     this.channel.onClose(e => this.emit('close', e))
-    this.channel.onError(e => this.emit('error', e))
+
+    this.channel.onError((e) => {
+      this.channel.leave()
+      this.socket.reconnectTimer.callback = () => { } // noops to prevent auto reconnects
+      this.socket.disconnect()
+      this.emit('error', e)
+    })
   }
 
   emit() {

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -67,7 +67,7 @@ export default class Terminal {
   }
 
   reset() {
-    return this.socket.reset();
+    return this.connect()
   }
 
   send(msg) {

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -13,7 +13,6 @@ export default class Terminal {
     this.token = args.token;
     this.username = args.username;
     this.labSlug = args.labSlug;
-    console.log('labslug', this.labSlug)
 
     this.hasFailed = false;
 
@@ -21,7 +20,7 @@ export default class Terminal {
   }
 
   connect() {
-    this.socket = new Socket(this.url(), {params: {token: this.token}})
+    this.socket = new Socket(this.url(), {params: {token: this.token, client: 'atom'}})
     this.socket.connect()
 
     this.channel = this.socket.channel(this.channelName())

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -1,6 +1,5 @@
 'use babel'
 
-import AtomSocket from 'atom-socket'
 import { EventEmitter } from 'events'
 import { Socket } from 'phoenix'
 
@@ -13,6 +12,8 @@ export default class Terminal {
     this.path = args.path;
     this.token = args.token;
     this.username = args.username;
+    this.labSlug = args.labSlug;
+    console.log('labslug', this.labSlug)
 
     this.hasFailed = false;
 
@@ -23,7 +24,7 @@ export default class Terminal {
     this.socket = new Socket(this.url(), {params: {token: this.token}})
     this.socket.connect()
 
-    this.channel = this.socket.channel(`session:${this.username}`)
+    this.channel = this.socket.channel(this.channelName())
 
     this.channel.join()
       .receive('error', (e) => { console.log('error connecting to session', e) })
@@ -54,6 +55,10 @@ export default class Terminal {
     var protocol = (this.port === 443) ? 'wss' : 'ws';
 
     return `${protocol}://${this.host}:${this.port}/${this.path}`;
+  }
+
+  channelName() {
+    return `session:${this.username}:${this.labSlug || 'lobby'}`
   }
 
   reset() {

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -3,7 +3,6 @@
 import url from 'url'
 import {ipcRenderer} from 'electron'
 import localStorage from './local-storage'
-import bus from './event-bus'
 
 function getLabSlug() {
   let {urlToOpen} = JSON.parse(decodeURIComponent(location.hash.substr(1)));

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -6,33 +6,16 @@ import localStorage from './local-storage'
 import bus from './event-bus'
 
 function getLabSlug() {
-  var {urlToOpen} = JSON.parse(decodeURIComponent(location.hash.substr(1)));
+  let {urlToOpen} = JSON.parse(decodeURIComponent(location.hash.substr(1)));
   return url.parse(urlToOpen).pathname.substring(1);
-};
+}
 
-function openInNewWindow() {
-  localStorage.set('learnOpenLabOnActivation', getLabSlug());
+function openLab(labSlug) {
+  localStorage.set('learnOpenLabOnActivation', labSlug);
   ipcRenderer.send('command', 'application:new-window');
-};
-
-function openInExistingWindow() {
-  bus.emit('learn:open', {timestamp: Date.now(), slug: getLabSlug()})
-}
-
-function windowOpen() {
-  return localStorage.get('lastFocusedWindow')
-}
-
-function onWindows() {
-  return process.platform === 'win32'
 }
 
 export default function() {
-  if (!windowOpen() || onWindows()) {
-    openInNewWindow();
-  } else {
-    openInExistingWindow();
-  }
-
+  openLab(getLabSlug());
   return Promise.resolve();
-};
+}

--- a/package.json
+++ b/package.json
@@ -215,6 +215,13 @@
       "default": 14,
       "minimum": 2,
       "description": "The name of the font size used in the terminal."
+    },
+    "openOnHome": {
+      "order": 5,
+      "type": "boolean",
+      "default": false,
+      "title": "Set Home as the Default Project",
+      "description": "When the Learn IDE is opened without a lab, open the tree on the remote server's home directory rather than 'temporary' (your work will still NOT be persisted; in other words, it is still temporary, just in a different location)."
     }
   }
 }


### PR DESCRIPTION
Disables phoenix's websocket reconnect behavior and updates our `reset` code paths with the correct APIs for resetting the connection. Depends on https://github.com/learn-co/nsync-fs/pull/18 for tree view compatibility.