### PR TITLE
Always check current version for equality with latest

### DIFF
--- a/lib/learn-ide.js
+++ b/lib/learn-ide.js
@@ -119,11 +119,6 @@ export default {
 
     this.subscriptions.add(
       atom.config.onDidChange(`${name}.bleedingUpdates`, ({newValue}) => {
-        var key = 'learn-ide:shouldRollback';
-        var didSubscribe = newValue;
-
-        didSubscribe ? localStorage.delete(key) : localStorage.set(key, Date.now())
-
         updater.checkForUpdate()
       })
     )

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -113,22 +113,7 @@ export default {
   _shouldUpdatePackage(latestVersion) {
     var {version} = require('../package.json');
 
-    if (this._shouldRollback()) {
-      return !semver.eq(latestVersion, version)
-    }
-
-    return semver.gt(latestVersion, version)
-  },
-
-  _shouldRollback() {
-    var rollback = parseInt(localStorage.get('learn-ide:shouldRollback'));
-
-    if (!rollback) { return false }
-
-    var twelveHours = 12 * 60 * 60;
-    var rollbackExpires = rollback + twelveHours;
-
-    return rollbackExpires > Date.now()
+    return !semver.eq(latestVersion, version)
   },
 
   _shouldUpdateDependencies() {


### PR DESCRIPTION
This will make it so that regardless of what is manually installed, we are pushing users to use our latest version (whether stable or bleeding) as defined by learn.co

cc @aturkewi 